### PR TITLE
Remove lib32-libglvnd from dependencies

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -12,7 +12,6 @@ pkgbase = flutter
 	makedepends = python
 	depends = glu
 	depends = java-environment
-	depends = lib32-libglvnd
 	optdepends = android-sdk
 	optdepends = android-studio
 	optdepends = bash

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,7 +8,7 @@ pkgdesc="A new mobile app SDK to help developers and designers build modern mobi
 arch=("x86_64")
 url="https://${pkgname}.io"
 license=("custom" "BSD" "CCPL")
-depends=("glu" "java-environment" "lib32-libglvnd")
+depends=("glu" "java-environment")
 optdepends=(
   "android-sdk"
   "android-studio"


### PR DESCRIPTION
Previous situation:
 - error: unable to satisfy dependency 'lib32-libglvnd' required by flutter
 - You have to install flutter as explained in the official website

Situation after this commit:
 - The package compiles successfully
 - Nothing seems change