### PR TITLE
Fix build with fakeroot

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -25,16 +25,19 @@ sha256sums=(
   "7ef10d753cfaac52d243549764a793f44f8284a1f4b11715ccd2fa915b026a6f"
 )
 
-package() {
+build() {
   rm -rf "${srcdir}/${pkgname}/bin/cache" "${srcdir}/${pkgname}/.pub-cache"
+  "${srcdir}/${pkgname}/bin/internal/update_dart_sdk.sh"
+  "${srcdir}/${pkgname}/bin/flutter" precache
+}
+
+package() {
   install -Dm644 "${srcdir}/${pkgname}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
   install -Dm755 "${srcdir}/${pkgname}.sh" "${pkgdir}/etc/profile.d/${pkgname}.sh"
   install -Dm755 "${srcdir}/${pkgname}.csh" "${pkgdir}/etc/profile.d/${pkgname}.csh"
   install -dm755 "${pkgdir}/opt/${pkgname}"
   install -dm755 "${pkgdir}/usr/bin"
   cp -ra "${srcdir}/${pkgname}" "${pkgdir}/opt/"
-  "${pkgdir}/opt/${pkgname}/bin/internal/update_dart_sdk.sh"
-  "${pkgdir}/opt/${pkgname}/bin/flutter" precache
   find "${pkgdir}/opt/${pkgname}" -type d -exec chmod a+rx {} +
   find "${pkgdir}/opt/${pkgname}" -type f -exec chmod a+r {} +
   # those files *must* be read-write for end-users; not my fault *grumble*


### PR DESCRIPTION
Building under fakeroot with a non root user lead to

Downloading Gradle Wrapper...                                       15ms
/usr/bin/tar: gradle/wrapper/gradle-wrapper.properties: Cannot change ownership to uid 397546, gid 5000: Invalid argument
/usr/bin/tar: gradle/wrapper/gradle-wrapper.jar: Cannot change ownership to uid 397546, gid 5000: Invalid argument
/usr/bin/tar: gradle/wrapper: Cannot change ownership to uid 397546, gid 5000: Invalid argument
/usr/bin/tar: gradle: Cannot change ownership to uid 397546, gid 5000: Invalid argument
/usr/bin/tar: gradlew: Cannot change ownership to uid 397546, gid 5000: Invalid argument
/usr/bin/tar: gradlew.bat: Cannot change ownership to uid 397546, gid 5000: Invalid argument
/usr/bin/tar: NOTICE: Cannot change ownership to uid 397546, gid 5000: Invalid argument
/usr/bin/tar: Exiting with failure status due to previous errors
Flutter could not download and/or extract https://storage.googleapis.com/flutter_infra_release/gradle-wrapper/fd5c1f2c013565a3bea56ada6df9d2b8e96d56aa/gradle-wrapper.tgz. Ensure you have network connectivity and all of the required
dependencies listed at flutter.dev/setup.
The original exception was: ProcessException: The command failed
  Command: tar -xzf /home/celogeek/tmp/flutter/pkg/flutter/opt/flutter/bin/cache/downloads/storage.googleapis.com/flutter_infra_release/gradle-wrapper/fd5c1f2c013565a3bea56ada6df9d2b8e96d56aa/gradle-wrapper.tgz -C
  /home/celogeek/tmp/flutter/pkg/flutter/opt/flutter/bin/cache/artifacts/gradle_wrapper.
==> ERROR: A failure occurred in package().
    Aborting...

This patch prepare the data during the build phase, then we copy the result.